### PR TITLE
Fix Netbox API ip-addresses url

### DIFF
--- a/racktables2netbox.py
+++ b/racktables2netbox.py
@@ -99,7 +99,7 @@ class REST(object):
         self.uploader(data, url)
 
     def post_ip(self, data):
-        url = self.base_url + '/ipam/ip-addresses1/'
+        url = self.base_url + '/ipam/ip-addresses/'
         logger.info('Posting IP data to {}'.format(url))
         self.uploader(data, url)
 


### PR DESCRIPTION
There is a typo in `racktables2netbox.py` at https://github.com/goebelmeier/racktables2netbox/blob/279cf9f24fc5bb0c4da97064503a4b87c95ae378/racktables2netbox.py#L102

After fixing URL to proper link, the scripts runs fine.

- Testing Environment:
  - Netbox v2.10.6
  -  MySQL (racktables database) - 5.7 